### PR TITLE
chore(deploy): rename fly app to masklm-daiki

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -3,7 +3,7 @@
 # See https://fly.io/docs/reference/configuration/ for information about how to use this file.
 #
 
-app = 'masklm-api'
+app = 'masklm-daiki'
 primary_region = 'sjc'
 
 [build]

--- a/frontend/vercel.json
+++ b/frontend/vercel.json
@@ -8,7 +8,7 @@
       "headers": [
         {
           "key": "Content-Security-Policy",
-          "value": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self' https://masklm-api.fly.dev https://rannqpdkygyyfiedypgk.supabase.co; font-src 'self'"
+          "value": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self' https://masklm-daiki.fly.dev https://rannqpdkygyyfiedypgk.supabase.co; font-src 'self'"
         },
         {
           "key": "X-Content-Type-Options",


### PR DESCRIPTION
## Summary
- Rename fly.io app from `masklm-api` (Jason's account) to `masklm-daiki` so Daiki can redeploy the backend on his own fly.io account
- Update Vercel CSP `connect-src` in `frontend/vercel.json` to match the new backend hostname

## Why
fly.io app names are globally unique across all accounts, so `masklm-api` cannot be reused. Daiki's fly.io launcher flow needs a fresh name.

## Follow-ups after merge
- On fly.io UI: deploy with app name `masklm-daiki`
- Set fly secret: `fly secrets set ALLOWED_ORIGINS="https://mask-lm.vercel.app,http://localhost:5173" -a masklm-daiki`
- Update Vercel env var `VITE_API_URL` to `https://masklm-daiki.fly.dev` and redeploy

## Test plan
- [ ] PR merges cleanly
- [ ] fly.io deploys successfully under new app name
- [ ] Vercel frontend connects to new backend (no CSP errors in browser console)
- [ ] End-to-end mask/unmask flow works

Generated with [Claude Code](https://claude.com/claude-code)
