### PR TITLE
chore(cors): add Vercel origin to ALLOWED_ORIGINS

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -9,7 +9,7 @@ primary_region = 'sjc'
 [build]
 
 [env]
-  ALLOWED_ORIGINS = 'http://localhost:5173,http://localhost:3000'
+  ALLOWED_ORIGINS = 'https://mask-lm.vercel.app,http://localhost:5173,http://localhost:3000'
 
 [http_service]
   internal_port = 8000


### PR DESCRIPTION
## Summary
- Add `https://mask-lm.vercel.app` (Daiki's Vercel production URL) to the `ALLOWED_ORIGINS` env var in `fly.toml`
- Keep existing localhost origins for local development

## Why
The backend is now redeployed at `masklm-daiki.fly.dev` on Daiki's account. Without the Vercel origin in the CORS allowlist, the frontend at `https://mask-lm.vercel.app` will be blocked when calling the new backend.

## Test plan
- [ ] PR merges and triggers Fly Deploy workflow
- [ ] After deploy, browser console shows no CORS errors when frontend makes API calls
- [ ] mask/unmask flow works end-to-end
