### PR TITLE
Add GitHub Actions workflow to keep Supabase project alive

### DIFF
--- a/.github/workflows/keep-supabase-alive.yml
+++ b/.github/workflows/keep-supabase-alive.yml
@@ -1,0 +1,21 @@
+name: Keep Supabase Alive
+
+on:
+  schedule:
+    - cron: '0 9 * * 1'
+  workflow_dispatch:
+
+jobs:
+  ping-supabase:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Ping Supabase REST API
+        run: |
+          response=$(curl -s -o /dev/null -w "%{http_code}" \
+            "https://${{ secrets.SUPABASE_PROJECT_REF }}.supabase.co/rest/v1/" \
+            -H "apikey: ${{ secrets.SUPABASE_ANON_KEY }}")
+          echo "Supabase responded with status: $response"
+          if [ "$response" -ge 500 ]; then
+            echo "Supabase might be down or paused"
+            exit 1
+          fi


### PR DESCRIPTION
## Summary
- Adds a weekly scheduled GitHub Actions workflow (Mondays 09:00 UTC) that pings the Supabase REST API to keep the project from pausing due to inactivity.
- Also supports manual trigger via workflow_dispatch.
- Uses existing repo secrets (SUPABASE_PROJECT_REF, SUPABASE_ANON_KEY); no values are hardcoded or printed.

## Test plan
- [ ] Merge to main
- [ ] Run `gh workflow run keep-supabase-alive.yml --ref main` and confirm a successful run in `gh run list --workflow=keep-supabase-alive.yml`